### PR TITLE
New selector for removed appcontent element

### DIFF
--- a/chrome/EdgyArc-fr/autohide-sidebar-modified.css
+++ b/chrome/EdgyArc-fr/autohide-sidebar-modified.css
@@ -105,11 +105,13 @@ See the above repository for updates as well as full license text. */
   }
 
   /* Move statuspanel to the other side when sidebar is hovered so it doesn't get covered by sidebar */
-  #sidebar-box:not([positionend]):hover ~ #appcontent #statuspanel {
+  #sidebar-box:not([positionend]):hover ~ #appcontent #statuspanel,
+  #sidebar-box:not([positionend]):hover ~ #tabbrowser-tabpanels #statuspanel {
     inset-inline: auto 0px !important;
   }
 
-  #sidebar-box:not([positionend]):hover ~ #appcontent #statuspanel-label {
+  #sidebar-box:not([positionend]):hover ~ #appcontent #statuspanel-label,
+  #sidebar-box:not([positionend]):hover ~ #tabbrowser-tabpanels #statuspanel-label {
     margin-inline: 0px !important;
     border-left-style: solid !important;
   }

--- a/chrome/global/browser.css
+++ b/chrome/global/browser.css
@@ -88,13 +88,15 @@
     --uc-tweak-rounded-corners-shadow: unset;
   }
 
-  #appcontent .browserStack {
+  #appcontent .browserStack,
+  #tabbrowser-tabpanels .browserStack {
     border-radius: var(--uc-tweak-rounded-corners-radius) !important;
     box-shadow: var(--uc-tweak-rounded-corners-shadow) !important;
   }
 
   /* Apply rounded corners to the browser container. */
-  #appcontent .browserStack {
+  #appcontent .browserStack,
+  #tabbrowser-tabpanels .browserStack {
     position: relative !important;
     overflow: hidden !important;
 
@@ -106,18 +108,21 @@
   }
 
   /* Devtools bottom */
-  #appcontent .browserStack:has(~ .devtools-toolbox-bottom-iframe) {
+  #appcontent .browserStack:has(~ .devtools-toolbox-bottom-iframe),
+  #tabbrowser-tabpanels .browserStack:has(~ .devtools-toolbox-bottom-iframe) {
     margin-block-end: calc(var(--uc-tweak-rounded-corners-padding) / 2);
   }
   .devtools-toolbox-bottom-iframe {
     margin-block-start: calc(var(--uc-tweak-rounded-corners-padding) / 2);
   }
   /* Devtools right */
-  #appcontent .browserContainer:not(:last-child) {
+  #appcontent .browserContainer:not(:last-child),
+  #tabbrowser-tabpanels .browserContainer:not(:last-child) {
     margin-inline-end: var(--uc-tweak-rounded-corners-padding);
   }
   /* Devtools left */
-  #appcontent .browserContainer:not(:first-child) {
+  #appcontent .browserContainer:not(:first-child),
+  #tabbrowser-tabpanels .browserContainer:not(:first-child) {
     margin-inline-start: var(--uc-tweak-rounded-corners-padding);
   }
 


### PR DESCRIPTION
#appcontent is no longer in the browser DOM. Added a fallback selector with #appcontent replaced with #tabbrowser-tabpanels