### PR TITLE
Fixes for FF135

### DIFF
--- a/chrome/EdgyArc-fr/edge-sidebar.css
+++ b/chrome/EdgyArc-fr/edge-sidebar.css
@@ -53,7 +53,6 @@
     transition: var(--af-bg-transition) !important;
   }
 
-  #main-window::after,
   #browser::before {
     content: "";
     display: block;

--- a/chrome/EdgyArc-fr/main.css
+++ b/chrome/EdgyArc-fr/main.css
@@ -120,13 +120,13 @@
   &:has(#sidebar-box[sidebarcommand="_3c078156-979c-498b-8990-85f7987dd929_-sidebar-action"]:not([hidden])),
   &:has(#sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]:not([hidden])),
   &:has(#sidebar-box[sidebarcommand="tabcenter-reborn_ariasuni-sidebar-action"]:not([hidden])) {
-    &[tabsintitlebar] #nav-bar {
+    &:not([drawtitle]) #nav-bar {
       --uc-tab-top-margin: 0px;
     }
   }
 
   @media (-moz-bool-pref: "uc.tweak.hide-tabs-bar.always") {
-    &[tabsintitlebar] #nav-bar {
+    &:not([drawtitle]) #nav-bar {
       --uc-tab-top-margin: 0px;
     }
   }
@@ -191,7 +191,8 @@
 /*fade toolbar background image for lwthemes - goes really great with Firefox Color setups!*/
 #navigator-toolbox {
   border-bottom: none !important;
-  &:-moz-lwtheme {
+  
+  :root[lwtheme] & {
     background-image: none !important; /*remove the background image from the actual toolbox*/
     &::after {
       content: "";
@@ -243,7 +244,7 @@
 /* macOS specific positioning */
 @media (-moz-platform: macos) {
   /* Offset navbar contents to make space for the window controls */
-  &[tabsintitlebar]:not([inFullscreen]) #nav-bar {
+  &:not([drawtitle]):not([inFullscreen]) #nav-bar {
     padding-left: calc(0px + var(--uc-titlebar-drag-space)) !important;
 
     /* Remove the padding from the side of the navbar */
@@ -267,7 +268,7 @@
     border-radius: 6px !important;
     margin: 4px !important;
   }
-  :root[sizemode="normal"][tabsintitlebar]:not([inFullscreen]) .titlebar-button {
+  :root[sizemode="normal"]:not([drawtitle]):not([inFullscreen]) .titlebar-button {
     margin-top: 5px !important;
   }
   #urlbar,

--- a/chrome/EdgyArc-fr/translucent-arc.css
+++ b/chrome/EdgyArc-fr/translucent-arc.css
@@ -18,6 +18,7 @@
     var(--browser-frame-bgcolor),
     transparent calc((1 - var(--af-minimal-opacity)) * 100%)
   ) !important;
+  background-image: none !important
 }
 
 /* Fixes transparent toolbar in fullscreen on macos */

--- a/chrome/global/browser.css
+++ b/chrome/global/browser.css
@@ -4,7 +4,7 @@
 /* Windows has 1px missing space on top of window, but not when accent colour is
  * applied to the title bar. */
 @media (-moz-platform: windows) and (not (-moz-windows-accent-color-in-titlebar)) {
-  :root[sizemode="normal"][tabsintitlebar]:not([inFullscreen]) #navigator-toolbox {
+  :root[sizemode="normal"]:not([drawtitle]):not([inFullscreen]) #navigator-toolbox {
     padding-top: 1px !important;
   }
 }

--- a/chrome/global/colors.css
+++ b/chrome/global/colors.css
@@ -133,12 +133,12 @@
 
 /* Make sure that the tab toolbar opacity is always 1, inactive window colours
  * are already supplied by this theme. */
-:root[tabsintitlebar] #titlebar:-moz-window-inactive {
+:root:not([drawtitle]) #titlebar:-moz-window-inactive {
   opacity: 1 !important;
 }
 
 /* Make the titlebar buttons black/white on default themes */
-:root:not([lwtheme])[tabsintitlebar] .titlebar-buttonbox {
+:root:not([lwtheme]):not([drawtitle]) .titlebar-buttonbox {
   color: var(--lwt-text-color) !important;
 }
 

--- a/chrome/global/tweaks.css
+++ b/chrome/global/tweaks.css
@@ -100,7 +100,7 @@ bugs with certain themes eg. dark text on dark background.) */
     }
   }
 
-  :root:is([inFullscreen], :not([tabsintitlebar])) {
+  :root:is([inFullscreen], [drawtitle]) {
     --uc-tab-top-margin: 4px !important;
   }
 

--- a/chrome/toolbar/tabbar.css
+++ b/chrome/toolbar/tabbar.css
@@ -9,7 +9,7 @@
   /* Remove extra space at the top of the window when in fullscreen or when
    * title bars are enabled. */
   &[inFullscreen],
-  &:not([tabsintitlebar]) {
+  &[drawtitle] {
     --uc-tab-top-margin: 0px !important;
   }
 
@@ -655,7 +655,7 @@
   /* If the titlebar buttons are on the right, then use the alternate gradient
    * if the menu bar is not permanently enabled. */
   @media (-moz-platform: windows), (-moz-gtk-csd-available) and (not (-moz-gtk-csd-reversed-placement)) {
-    :root[tabsintitlebar] #toolbar-menubar:not([autohide="false"]) ~ #TabsToolbar & {
+    :root:not([drawtitle]) #toolbar-menubar:not([autohide="false"]) ~ #TabsToolbar & {
       background: var(--uc-gradient-alt);
     }
   }

--- a/chrome/tweaks/hide-tabs-bar.css
+++ b/chrome/tweaks/hide-tabs-bar.css
@@ -20,12 +20,12 @@
   }
 
   /* Fix issue with missing window controls. */
-  &[tabsintitlebar] #titlebar {
+  &:not([drawtitle]) #titlebar {
     will-change: auto !important;
   }
 
   /* Add some padding to the top of the navbar */
-  &[tabsintitlebar] #nav-bar {
+  &:not([drawtitle]) #nav-bar {
     padding-top: var(--uc-tab-top-margin, 0) !important;
   }
 
@@ -38,7 +38,7 @@
   /* macOS specific positioning */
   @media (-moz-platform: macos) {
     /* Offset navbar contents to make space for the window controls */
-    &[tabsintitlebar]:not([inFullscreen]) #nav-bar {
+    &:not([drawtitle]):not([inFullscreen]) #nav-bar {
       padding-left: calc(70px + var(--uc-titlebar-drag-space)) !important;
 
       /* Remove the padding from the side of the navbar */
@@ -65,7 +65,7 @@
   /* Windows specific positioning */
   @media (-moz-platform: windows) {
     /* Offset navbar contents to make space for the window controls */
-    &:where([inFullscreen], [tabsintitlebar]) #nav-bar {
+    &:where([inFullscreen], :not([drawtitle])) #nav-bar {
       padding-inline-end: calc(140px + var(--uc-titlebar-drag-space)) !important;
 
       /* Remove the padding from the side of the navbar */
@@ -108,7 +108,7 @@
     }
 
     /* Offset navbar contents to make space for the window controls */
-    &:where([inFullscreen], [tabsintitlebar]) #nav-bar {
+    &:where([inFullscreen], :not([drawtitle])) #nav-bar {
       /* Window controls on the right. */
       @media not (-moz-gtk-csd-reversed-placement) {
         padding-inline-end: calc(var(--uc-window-controls-width, 0px) + var(--uc-titlebar-drag-space)) !important;
@@ -237,12 +237,12 @@
     }
 
     /* Fix issue with missing window controls. */
-    &[tabsintitlebar] #titlebar {
+    &:not([drawtitle]) #titlebar {
       will-change: auto !important;
     }
 
     /* Add some padding to the top of the navbar */
-    &[tabsintitlebar] #nav-bar {
+    &:not([drawtitle]) #nav-bar {
       padding-top: var(--uc-tab-top-margin, 0) !important;
     }
 
@@ -255,7 +255,7 @@
     /* macOS specific positioning */
     @media (-moz-platform: macos) {
       /* Offset navbar contents to make space for the window controls */
-      &[tabsintitlebar]:not([inFullscreen]) #nav-bar {
+      &:not([drawtitle]):not([inFullscreen]) #nav-bar {
         padding-left: calc(70px + var(--uc-titlebar-drag-space)) !important;
 
         /* Remove the padding from the side of the navbar */
@@ -282,7 +282,7 @@
     /* Windows specific positioning */
     @media (-moz-platform: windows) {
       /* Offset navbar contents to make space for the window controls */
-      &:where([inFullscreen], [tabsintitlebar]) #nav-bar {
+      &:where([inFullscreen], :not([drawtitle])) #nav-bar {
         padding-inline-end: calc(140px + var(--uc-titlebar-drag-space)) !important;
 
         /* Remove the padding from the side of the navbar */
@@ -325,7 +325,7 @@
       }
 
       /* Offset navbar contents to make space for the window controls */
-      &:where([inFullscreen], [tabsintitlebar]) #nav-bar {
+      &:where([inFullscreen], :not([drawtitle])) #nav-bar {
         /* Window controls on the right. */
         @media not (-moz-gtk-csd-reversed-placement) {
           padding-inline-end: calc(var(--uc-window-controls-width, 0px) + var(--uc-titlebar-drag-space)) !important;


### PR DESCRIPTION
Closes #10, #8 

Will probably break support for versions before FF135, maybe wait to merge until FF135 is released? Otherwise I could look into updating the PR to support both <135 and >135.

Haven't tested Windows yet, will test later tonight.

With `af.edgyarc.macos-translucent`
![Screenshot 2025-01-08 at 6 37 35 PM](https://github.com/user-attachments/assets/cc65f2e0-34de-4ee6-99c4-372a5eecce3d)

Without `af.edgyarc.macos-translucent`
![Screenshot 2025-01-08 at 6 38 19 PM](https://github.com/user-attachments/assets/f2039091-5755-4a87-a570-33ff4ac4b1e2)

Fullscreen
![Screenshot 2025-01-08 at 6 39 05 PM](https://github.com/user-attachments/assets/10790046-9d96-46d9-bf97-a5b9d0d00541)
