### PR TITLE
Fix icon alignment and title padding in sidebar

### DIFF
--- a/chrome/EdgyArc-fr/sidebery.css
+++ b/chrome/EdgyArc-fr/sidebery.css
@@ -292,7 +292,11 @@
 
       /*adjust padding to accomodate coloured tabs*/
       .t-box {
-        padding: 0 6px !important;
+        padding: 0 12px !important;
+      }
+
+      .fav {
+        margin-left: 8px !important;
       }
     }
 


### PR DESCRIPTION
Before: #30 
After:
<img width="287" height="51" alt="Screenshot 2026-02-02 at 07 36 40" src="https://github.com/user-attachments/assets/9ec4de0b-5b06-4b0c-b70b-f0984a67144b" />


Fixes #30 